### PR TITLE
Fix use-window.test.tsx to use act

### DIFF
--- a/src/hooks/use-window.test.tsx
+++ b/src/hooks/use-window.test.tsx
@@ -1,4 +1,4 @@
-import { renderHook } from "@testing-library/react-hooks";
+import { renderHook, act } from "@testing-library/react-hooks";
 import { useWindow } from "./use-window";
 
 const DEFAULT_WIDTH: number = 1024;
@@ -6,7 +6,9 @@ const DEFAULT_HEIGHT: number = 768;
 
 describe("useWindow", () => {
     beforeEach(() => {
-        window.resizeTo(DEFAULT_WIDTH, DEFAULT_HEIGHT);
+        act(() => {
+            window.resizeTo(DEFAULT_WIDTH, DEFAULT_HEIGHT);
+        });
     });
 
     test("returns width and height of window", async () => {
@@ -25,7 +27,9 @@ describe("useWindow", () => {
         const windowHeight = DEFAULT_HEIGHT + 1;
 
         // Act
-        window.resizeTo(windowWidth, windowHeight);
+        act(() => {
+            window.resizeTo(windowWidth, windowHeight);
+        });
 
         // Assert
         expect(result.current.width).toBe(windowWidth);


### PR DESCRIPTION
Fixes #45 console warnings

- [x] Related GitHub issue(s) linked in PR description
- [x] Destination branch merged, built and tested with your changes
- [x] Code formatted and follows best practices and patterns
- [x] Code builds cleanly (no _additional_ warnings or errors)
- [x] Manually tested
- [x] Automated tests are passing
- [x] No _decreases_ in automated test coverage
- [-] Documentation updated (readme, docs, comments, etc.)
- [-] Localization: No hard-coded error messages in code files (_minimally_ in string constants)

Per https://react-hooks-testing-library.com/usage/basic-hooks#updates, whenever an action causes the state of the hook to change, it should be wrapped in `act`