### PR TITLE
Additional safeguards for re-renders and error types

### DIFF
--- a/src/hooks/use-page-errors.ts
+++ b/src/hooks/use-page-errors.ts
@@ -1,5 +1,5 @@
 import { useState, useCallback } from "react";
-import { ResultRecord } from "andculturecode-javascript-core";
+import { CollectionUtils, ResultRecord } from "andculturecode-javascript-core";
 
 /**
  * Hook to bundle common page error handling functionality
@@ -7,20 +7,27 @@ import { ResultRecord } from "andculturecode-javascript-core";
 export function usePageErrors() {
     const [pageErrors, setPageErrors] = useState<Array<string>>([]);
 
-    const handlePageLoadError = useCallback(
-        (result: string | ResultRecord<any>) => {
-            if (typeof result === "string") {
-                setPageErrors((e) => [...e, result]);
-                return;
-            }
+    const handlePageLoadError = useCallback((result: any) => {
+        if (result instanceof ResultRecord) {
+            setPageErrors((errors: string[]) => [
+                ...errors,
+                ...result.listErrorMessages(),
+            ]);
+            return;
+        }
 
-            setPageErrors((e) => [...e, ...result.listErrorMessages()]);
-        },
-        []
-    );
+        if (typeof result === "string") {
+            setPageErrors((errors: string[]) => [...errors, result]);
+            return;
+        }
+
+        setPageErrors((errors: string[]) => [...errors, result.toString()]);
+    }, []);
 
     const resetPageErrors = useCallback(() => {
-        setPageErrors([]);
+        setPageErrors((prevState) =>
+            CollectionUtils.hasValues(prevState) ? [] : prevState
+        );
     }, []);
 
     return {


### PR DESCRIPTION
#67 Add additional safeguards
Covers errors that may not be strings or an instance of a ResultRecord.
Potentially prevent an unnecessary re-render by setting the state to the previous value when empty, rather than instantiating a new array.

- [x] Related GitHub issue(s) linked in PR description
- [x] Destination branch merged, built and tested with your changes
- [x] Code formatted and follows best practices and patterns
- [x] Code builds cleanly (no _additional_ warnings or errors)
- [x] Manually tested
- [x] Automated tests are passing
- [x] No _decreases_ in automated test coverage
- [x] Documentation updated (readme, docs, comments, etc.)
- [x] Localization: No hard-coded error messages in code files (_minimally_ in string constants)
